### PR TITLE
feat: adding a dev command for working on your tests

### DIFF
--- a/bin/teamjam.js
+++ b/bin/teamjam.js
@@ -19,6 +19,7 @@ const help = () => {
     `$ teamjam --help`,
     `$ teamjam play --url="http://..." --team="MY TEAM"`,
     `$ teamjam serve --problems=directory/with/problems`,
+    `$ teamjam dev --problems=directory/with/problems`,
     '',
   ].join('\n'))
 }
@@ -30,6 +31,7 @@ const main = async () => {
     case !!argv.help: return help()
     case command === 'serve': return require('../server')(argv)
     case command === 'play': return require('../client')(argv)
+    case command === 'dev': return require('../test/devTests')(argv)
     default: throw new Error('Invalid command')
   }
 }

--- a/example/asyc.js
+++ b/example/asyc.js
@@ -1,0 +1,16 @@
+exports.title = 'abc'
+exports.points = 200
+exports.description = `
+  Given a promise of a number return a promise of its double.
+`
+
+exports.solution = (p) => {
+  return p.then(n => n * 2)
+}
+
+exports.test = async (fn) => {
+  const assert = require('assert')
+  const p = Promise.resolve(2)
+  const v = await fn(p)
+  assert.strictEqual(v, 4, 'should double the promise')
+}

--- a/test/devTests.js
+++ b/test/devTests.js
@@ -1,0 +1,27 @@
+const path = require('path')
+const chalk = require('chalk')
+const chokidar = require('chokidar')
+const { runTestFromFile } = require('./index')
+
+module.exports = async function getTests({ problems }) {
+  const dir = path.resolve(process.cwd(), problems)
+
+  console.log(`> developing tests from: ${chalk.cyan(dir)}`)
+
+  const watcher = chokidar.watch(path.resolve(dir, '*.js'))
+
+  const checkFile = async (f) => {
+    const result = await runTestFromFile(f)
+
+    if (result.status === 'passed') {
+      console.log(chalk.green(`✓ ${result.id}`))
+    } else {
+      console.log(chalk.red(`✘ ${result.id}`))
+      console.log('')
+      console.log(result.error)
+    }
+  }
+
+  watcher.on('add', checkFile)
+  watcher.on('change', checkFile)
+}

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -52,7 +52,7 @@ module.exports = async function runTest(test, solution, callback) {
 
   try {
     const t = testVm.run(test.code, test.file)
-    const s = solution && sandbox.run(solution.code, solution.file)
+    const s = sandbox.run(solution.code, solution.file)
 
     assert.strictEqual(typeof t.points, 'number', `${id} must export points`)
     assert.strictEqual(typeof t.test, 'function', `${id} must export test`)
@@ -64,7 +64,7 @@ module.exports = async function runTest(test, solution, callback) {
       assert.strictEqual(typeof s.solution, 'function', `${path.basename(solution.file)} must export solution`)
     }
 
-    await t.test(solution ? s.solution : t.solution)
+    await t.test(s.solution)
 
     callback(null, {
       id: id,
@@ -77,6 +77,7 @@ module.exports = async function runTest(test, solution, callback) {
       consoleOutput: getConsoleOutput(),
     })
   } catch (e) {
+    console.log(e.stack)
     e.stack = stack.clean(e.stack)
 
     callback(null, {


### PR DESCRIPTION
this creates a command like: 

```
$ teamjam dev --problems path/to/problems
```

to help you watch your tests and run them so you can work out the problems without serving the app.

closes #11 